### PR TITLE
Fix typos in living_lexicon_discussion

### DIFF
--- a/living_lexicon_discussion.md
+++ b/living_lexicon_discussion.md
@@ -945,7 +945,7 @@ first of all it should be made in /home/lloyd/eidosian_forge/word_forge
 We also want the repo structure to be set up like /word_forge/src/word_forge
 
 So that in the main repo folder we can have all sorts of stuff
-And so that if we want to implement in other langauges we can have it in another fodler in the src directory.
+And so that if we want to implement in other languages we can have it in another folder in the src directory.
 
 We also already have a venv
 


### PR DESCRIPTION
## Summary
- correct spelling mistakes in living_lexicon_discussion.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b6b9062848323b2a6a8868d689561