### PR TITLE
Add basic Config.get_full_path test

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,23 @@
+"""Tests for :mod:`word_forge.config`."""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+def test_get_full_path_joins_data_dir(monkeypatch, tmp_path):
+    """Verify :func:`Config.get_full_path` joins ``parser.data_dir`` with a relative path."""
+
+    # Ensure repository source is on ``sys.path`` for import reliability
+    repo_src = Path(__file__).resolve().parents[1] / "src"
+    monkeypatch.syspath_prepend(str(repo_src))
+
+    # Override parser data directory before reloading the config module
+    monkeypatch.setenv("WORD_FORGE_DATA_DIR", str(tmp_path))
+    import word_forge.config as cfg
+
+    importlib.reload(cfg)
+    result = cfg.config.get_full_path("example.txt")
+    assert result == Path(tmp_path) / "example.txt"
+


### PR DESCRIPTION
## Summary
- add pytest for Config.get_full_path
- ensure test overrides data directory and reloads config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b6b92314083238b7a81b901f60f65