### PR TITLE
Add runtime requirements and dev docs

### DIFF
--- a/docs/development/dev_dependencies.md
+++ b/docs/development/dev_dependencies.md
@@ -1,0 +1,28 @@
+# Developer Dependencies
+
+> _"Development tools shape the quality and clarity of the codebase."_
+
+The following packages are required only for development and testing. They are
+not needed for running Word Forge in production environments.
+
+```text
+black
+isort
+mypy
+pytest
+pytest-cov
+```
+
+Each tool serves a distinct purpose:
+
+- **black** – Enforces a consistent code style across the project.
+- **isort** – Automatically sorts imports to reduce merge conflicts.
+- **mypy** – Provides optional static type checking.
+- **pytest** and **pytest-cov** – Run tests and measure code coverage.
+
+Install them with `pip` using the `--requirement` option if desired:
+
+```bash
+pip install -r requirements.txt  # runtime dependencies
+pip install black isort mypy pytest pytest-cov  # development only
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+nltk>=3.6.0
+torch>=1.9.0
+rdflib>=6.0.0
+transformers>=4.15.0


### PR DESCRIPTION
## Summary
- document developer dependencies
- list runtime dependencies in `requirements.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684b7323f0c4832384141c8a7774f6f8