### PR TITLE
Add core module tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [ "black", "isort", "mypy", "pytest", "pytest-cov" ]
+dev = [ "numpy>=1.23.0", "black", "isort", "mypy", "pytest", "pytest-cov" ]
 
 [tool.setuptools.packages.find]
 where   = [ "src" ]

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1,0 +1,107 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+import types
+chromadb = types.ModuleType("chromadb")
+chromadb.Client = lambda *a, **k: None
+chromadb.PersistentClient = lambda *a, **k: None
+sys.modules["chromadb"] = chromadb
+sentence_module = types.ModuleType("sentence_transformers")
+class DummyModel:
+    def __init__(self, *a, **k):
+        pass
+    def get_sentence_embedding_dimension(self):
+        return 5
+    def encode(self, *a, **k):
+        import numpy as np
+        return np.zeros(5, dtype=np.float32)
+sentence_module.SentenceTransformer = DummyModel
+sys.modules["sentence_transformers"] = sentence_module
+
+emotion_module = types.ModuleType("word_forge.emotion.emotion_manager")
+class DummyEmotionManager:
+    def process_message(self, message_id, text):
+        pass
+emotion_module.EmotionManager = DummyEmotionManager
+sys.modules["word_forge.emotion.emotion_manager"] = emotion_module
+graph_module = types.ModuleType("word_forge.graph.graph_manager")
+class DummyGraphManager:
+    pass
+graph_module.GraphManager = DummyGraphManager
+sys.modules["word_forge.graph.graph_manager"] = graph_module
+
+from types import SimpleNamespace
+
+import pytest
+
+from word_forge.conversation.conversation_manager import ConversationManager
+from word_forge.configs.config_essentials import Result
+from word_forge.database.database_manager import DBManager
+
+
+class StubModel:
+    def __init__(self, return_value=None):
+        self.return_value = return_value
+
+    def generate_reflex(self, context):
+        return Result.success(context)
+
+    def process(self, context):
+        return Result.success(context)
+
+    def generate_core_response(self, context):
+        context["intermediate_response"] = self.return_value or "ok"
+        return Result.success(context)
+
+    def refine_response(self, context):
+        return Result.success(self.return_value or "ok")
+
+
+class StubEmotionManager:
+    def process_message(self, message_id, text):
+        pass
+
+
+class StubGraphManager:
+    pass
+
+
+def create_manager(tmp_path):
+    db_path = tmp_path / "conv.db"
+    dbm = DBManager(db_path=db_path)
+    return ConversationManager(
+        db_manager=dbm,
+        emotion_manager=StubEmotionManager(),
+        graph_manager=StubGraphManager(),
+        vector_store=SimpleNamespace(),
+        reflexive_model=StubModel(),
+        lightweight_model=StubModel(),
+        affective_model=StubModel(),
+        identity_model=StubModel(),
+    )
+
+
+def test_conversation_flow(tmp_path):
+    cm = create_manager(tmp_path)
+    conv_id = cm.start_conversation().unwrap()
+    add_res = cm.add_message(conv_id, "User", "Hello", generate_response=False)
+    assert add_res.is_success
+    conv = cm.get_conversation(conv_id).unwrap()
+    assert len(conv["messages"]) == 1
+    assert conv["messages"][0]["text"] == "Hello"
+    end_res = cm.end_conversation(conv_id)
+    assert end_res.is_success
+
+
+def test_end_nonexistent_conversation(tmp_path):
+    cm = create_manager(tmp_path)
+    res = cm.end_conversation(999)
+    assert res.is_failure
+    assert res.error and res.error.code == "CONVERSATION_NOT_FOUND"
+
+
+def test_add_message_empty(tmp_path):
+    cm = create_manager(tmp_path)
+    conv_id = cm.start_conversation().unwrap()
+    with pytest.raises(ValueError):
+        cm.add_message(conv_id, "User", " ")

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+from word_forge.database.database_manager import DBManager, TermNotFoundError
+
+
+def test_insert_and_get_word(tmp_path):
+    db_path = tmp_path / "test.db"
+    dbm = DBManager(db_path=db_path)
+    dbm.insert_or_update_word("alpha", "first", "noun", ["example"])
+    word_id = dbm.get_word_id("alpha")
+    assert isinstance(word_id, int)
+
+
+def test_get_word_id_not_found(tmp_path):
+    db_path = tmp_path / "test.db"
+    dbm = DBManager(db_path=db_path)
+    dbm.create_tables()
+    with pytest.raises(TermNotFoundError):
+        dbm.get_word_id("missing")
+
+
+def test_insert_word_empty_term(tmp_path):
+    db_path = tmp_path / "test.db"
+    dbm = DBManager(db_path=db_path)
+    with pytest.raises(ValueError):
+        dbm.insert_or_update_word("")

--- a/tests/test_lexical_proto.py
+++ b/tests/test_lexical_proto.py
@@ -1,0 +1,99 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import types
+import importlib
+
+# Stub heavy dependencies before importing lexical_proto
+nltk = types.ModuleType("nltk")
+corpus = types.ModuleType("nltk.corpus")
+wordnet_mod = types.ModuleType("nltk.corpus.wordnet")
+reader_mod = types.ModuleType("nltk.corpus.reader.wordnet")
+class Lemma: ...
+class Synset: ...
+reader_mod.Lemma = Lemma
+reader_mod.Synset = Synset
+corpus.wordnet = wordnet_mod
+nltk.corpus = corpus
+nltk.download = lambda *a, **k: None
+sys.modules["nltk"] = nltk
+sys.modules["nltk.corpus"] = corpus
+sys.modules["nltk.corpus.wordnet"] = wordnet_mod
+sys.modules["nltk.corpus.reader"] = types.ModuleType("nltk.corpus.reader")
+sys.modules["nltk.corpus.reader.wordnet"] = reader_mod
+
+sys.modules["torch"] = types.ModuleType("torch")
+rdflib_mod = types.ModuleType("rdflib")
+class Graph: ...
+class Literal: ...
+class URIRef: ...
+rdflib_mod.Graph = Graph
+rdflib_mod.Literal = Literal
+rdflib_mod.URIRef = URIRef
+sys.modules["rdflib"] = rdflib_mod
+transformers_mod = types.ModuleType("transformers")
+class Dummy: ...
+transformers_mod.AutoModelForCausalLM = Dummy
+transformers_mod.AutoTokenizer = Dummy
+transformers_mod.PreTrainedModel = Dummy
+transformers_mod.PreTrainedTokenizer = Dummy
+transformers_mod.PreTrainedTokenizerFast = Dummy
+sys.modules["transformers"] = transformers_mod
+transformers_mod.generation = types.ModuleType("transformers.generation")
+utils_mod = types.ModuleType("transformers.generation.utils")
+class GenerateBeamDecoderOnlyOutput: ...
+class GenerateBeamEncoderDecoderOutput: ...
+class GenerateDecoderOnlyOutput: ...
+class GenerateEncoderDecoderOutput: ...
+utils_mod.GenerateBeamDecoderOnlyOutput = GenerateBeamDecoderOnlyOutput
+utils_mod.GenerateBeamEncoderDecoderOutput = GenerateBeamEncoderDecoderOutput
+utils_mod.GenerateDecoderOnlyOutput = GenerateDecoderOnlyOutput
+utils_mod.GenerateEncoderDecoderOutput = GenerateEncoderDecoderOutput
+transformers_mod.generation.utils = utils_mod
+sys.modules["transformers.generation"] = transformers_mod.generation
+sys.modules["transformers.generation.utils"] = utils_mod
+
+lexical_proto = importlib.import_module("lexical_proto")
+from lexical_proto import (
+    file_exists,
+    safely_open_file,
+    read_json_file,
+    read_jsonl_file,
+)
+
+import os
+import pytest
+
+
+def test_file_exists(tmp_path):
+    p = tmp_path / "t.txt"
+    assert not file_exists(p)
+    p.write_text("data")
+    assert file_exists(p)
+
+
+def test_safely_open_file_missing(tmp_path):
+    assert safely_open_file(tmp_path / "no.txt") is None
+
+
+def test_read_json_file_invalid(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("not json")
+    assert read_json_file(p, {"d": 1}) == {"d": 1}
+
+
+def test_read_jsonl_file(tmp_path):
+    p = tmp_path / "data.jsonl"
+    p.write_text('{"a":1}\ninvalid\n{"a":2}\n')
+
+    def proc(d):
+        return d["a"]
+
+    assert read_jsonl_file(p, proc) == [1, 2]
+
+
+def test_read_jsonl_file_missing(tmp_path):
+    p = tmp_path / "missing.jsonl"
+    assert read_jsonl_file(p, lambda d: d) == []

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import types
+chromadb = types.ModuleType("chromadb")
+chromadb.Client = lambda *a, **k: None
+chromadb.PersistentClient = lambda *a, **k: None
+sys.modules["chromadb"] = chromadb
+sentence_module = types.ModuleType("sentence_transformers")
+class DummyModel:
+    def __init__(self, *a, **k):
+        pass
+    def get_sentence_embedding_dimension(self):
+        return 5
+    def encode(self, text, normalize_embeddings=False, convert_to_numpy=True, show_progress_bar=False):
+        import numpy as np
+        return np.zeros(5, dtype=np.float32)
+sentence_module.SentenceTransformer = DummyModel
+sys.modules["sentence_transformers"] = sentence_module
+
+import numpy as np
+import pytest
+
+from word_forge.vectorizer.vector_store import VectorStore, DimensionMismatchError, SearchError
+
+
+def test_validate_vector_dimension_mismatch():
+    vs = object.__new__(VectorStore)
+    vs.dimension = 4
+    with pytest.raises(DimensionMismatchError):
+        vs._validate_vector_dimension(np.zeros(3, dtype=np.float32))
+
+
+def test_search_requires_input():
+    vs = object.__new__(VectorStore)
+    with pytest.raises(SearchError):
+        vs.search()


### PR DESCRIPTION
## Summary
- add unit tests for conversation manager, DB manager, vector store, and lexical helpers
- stub heavy dependencies for testing
- require numpy in dev extras for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b732dc8788323aa1c82b127afcef0