### PR TITLE
Refactor ModelState to instance-based design

### DIFF
--- a/src/word_forge/conversation/conversation_models.py
+++ b/src/word_forge/conversation/conversation_models.py
@@ -25,7 +25,7 @@ from word_forge.conversation.conversation_types import (
     ModelContext,
     ReflexiveModel,  # Import ReflexiveModel protocol
 )
-from word_forge.parser.language_model import ModelState as LLMInterface
+from word_forge.parser.language_model import ModelState
 
 # --- Mock Implementations ---
 
@@ -166,7 +166,11 @@ class EidosianIdentityModel(IdentityModel):  # Inherit from protocol
     stylistic adjustments.
     """
 
-    def __init__(self, initial_state: Optional[EidosianIdentityState] = None):
+    def __init__(
+        self,
+        initial_state: Optional[EidosianIdentityState] = None,
+        llm_state: Optional[ModelState] = None,
+    ):
         """Initializes the identity model with an optional starting state.
 
         Args:
@@ -174,8 +178,8 @@ class EidosianIdentityModel(IdentityModel):  # Inherit from protocol
                            If None, a default state is created.
         """
         self.state = initial_state or EidosianIdentityState()
-        # Ensure LLM is initialized (or attempt initialization)
-        if not LLMInterface.initialize():
+        self.llm_state = llm_state or ModelState()
+        if not self.llm_state.initialize():
             print(
                 "Warning: EidosianIdentityModel requires LLM, but initialization failed."
             )
@@ -214,13 +218,13 @@ class EidosianIdentityModel(IdentityModel):  # Inherit from protocol
                 error.code, error.message, error.context, error.category, error.severity
             )
 
-        if not LLMInterface.is_initialized():
+        if not self.llm_state.is_initialized():
             error = Error.create(
                 message="LLM required for EidosianIdentityModel refinement is not available.",
                 code="LLM_NOT_INITIALIZED",
                 category=ErrorCategory.RESOURCE,
                 severity=ErrorSeverity.ERROR,
-                context={"model_name": LLMInterface.get_model_name()},
+                context={"model_name": self.llm_state.get_model_name()},
             )
             return Result[str].failure(
                 error.code, error.message, error.context, error.category, error.severity
@@ -370,7 +374,7 @@ class EidosianIdentityModel(IdentityModel):  # Inherit from protocol
         self, prompt: str, max_tokens_factor: float = 1.2, temperature: float = 0.5
     ) -> Result[str]:
         """Helper method to call the LLM and handle potential errors."""
-        if not LLMInterface.is_initialized():
+        if not self.llm_state.is_initialized():
             error = Error.create(
                 message="LLM is not available.",
                 code="LLM_NOT_INITIALIZED",
@@ -385,7 +389,7 @@ class EidosianIdentityModel(IdentityModel):  # Inherit from protocol
         estimated_max_tokens = int(len(prompt.split()) * max_tokens_factor) + 50
         final_max_tokens = max(50, estimated_max_tokens)
 
-        llm_result = LLMInterface.generate_text(
+        llm_result = self.llm_state.generate_text(
             prompt, max_new_tokens=final_max_tokens, temperature=temperature
         )
 
@@ -466,7 +470,7 @@ class EidosianIdentityModel(IdentityModel):  # Inherit from protocol
             print(
                 f"EidosianIdentity: Performing periodic self-reflection (Interaction #{self.state.interaction_count})..."
             )
-            if not LLMInterface.is_initialized():
+            if not self.llm_state.is_initialized():
                 error = Error.create(
                     message="LLM needed for state update is not available.",
                     code="LLM_NOT_INITIALIZED",

--- a/src/word_forge/emotion/emotion_manager.py
+++ b/src/word_forge/emotion/emotion_manager.py
@@ -60,7 +60,7 @@ from word_forge.emotion.emotion_types import (
 )
 
 # LLM Interface
-from word_forge.parser.language_model import ModelState as LLMInterface
+from word_forge.parser.language_model import ModelState
 
 logger = logging.getLogger(__name__)
 VADER_AVAILABLE = True
@@ -185,11 +185,10 @@ class EmotionManager:
         # Initialize LLM if available
         try:
             if LLM_AVAILABLE:
-                # Actually test LLM initialization rather than just assuming
-                if LLMInterface.initialize():
-                    self.llm_interface = LLMInterface()
+                self.llm_interface = ModelState()
+                if self.llm_interface.initialize():
                     logger.info(
-                        f"LLM initialized successfully: {LLMInterface.model_name}"
+                        f"LLM initialized successfully: {self.llm_interface.model_name}"
                     )
                 else:
                     self.llm_interface = None

--- a/src/word_forge/parser/language_model.py
+++ b/src/word_forge/parser/language_model.py
@@ -19,102 +19,102 @@ nltk.download("omw-1.4", quiet=True)  # type: ignore
 
 
 class ModelState:
+    """Encapsulates a language model and tokenizer instance.
+
+    The previous implementation relied on class-level state and acted as a
+    singleton.  This version allows multiple independent model instances to be
+    created with different model names or devices.  Lazy initialization is still
+    used so the heavy transformer objects are only loaded when required.
     """
-    Manages transformer model state safely with lazy initialization.
 
-    This singleton class ensures the model is only loaded when needed
-    and properly configured for efficient inference.
-    """
+    def __init__(
+        self,
+        model_name: str = "qwen/qwen2.5-0.5b-instruct",
+        device: Optional[torch.device] = None,
+    ) -> None:
+        self.model_name = model_name
+        self.device = device or torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
+        self.tokenizer: Optional[
+            Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
+        ] = None
+        self.model: Optional[PreTrainedModel] = None
+        self._initialized: bool = False
+        self._inference_failures: int = 0
+        self._max_failures: int = 5
+        self._failure_threshold_reached: bool = False
 
-    _initialized = False
-    tokenizer: Optional[Union[PreTrainedTokenizer, PreTrainedTokenizerFast]] = None
-    model: Optional[PreTrainedModel] = None
-    model_name: str = "qwen/qwen2.5-0.5b-instruct"
-    _model_name: str = "qwen/qwen2.5-0.5b-instruct"
-    _device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    _inference_failures: int = 0
-    _max_failures: int = 5
-    _failure_threshold_reached: bool = False
+    def get_model_name(self) -> str:
+        """Return the configured model name."""
+        return self.model_name
 
-    @classmethod
-    def get_model_name(cls) -> str:
-        """Returns the configured model name."""
-        return cls._model_name
+    def is_initialized(self) -> bool:
+        """Check if the model and tokenizer are initialized."""
+        return self._initialized
 
-    @classmethod
-    def is_initialized(cls) -> bool:
-        """Checks if the model and tokenizer are initialized."""
-        return cls._initialized
+    def set_model(self, model_name: str) -> None:
+        """Change the model and reset initialization state."""
+        self.model_name = model_name
+        self._initialized = False  # Force reinitialization with new model
 
-    @classmethod
-    def set_model(cls, model_name: str) -> None:
-        """
-        Set the model to use for text generation.
-
-        Args:
-            model_name: Name of the Hugging Face model to use
-        """
-        cls._model_name = model_name
-        cls._initialized = False  # Force reinitialization with new model
-
-    @classmethod
-    def initialize(cls) -> bool:
+    def initialize(self) -> bool:
         """
         Initialize the model and tokenizer if not already done.
 
         Returns:
             True if initialization was successful, False otherwise
         """
-        if cls.is_initialized():
+        if self.is_initialized():
             return True
 
-        if cls._failure_threshold_reached:
+        if self._failure_threshold_reached:
             print(
-                f"Model initialization skipped: Failure threshold ({cls._max_failures}) reached."
+                f"Model initialization skipped: Failure threshold ({self._max_failures}) reached."
             )
             return False
 
         try:
             # Load tokenizer with explicit type annotation
-            cls.tokenizer = cast(
+            self.tokenizer = cast(
                 Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
                 AutoTokenizer.from_pretrained(
-                    cast(Union[str, PathLike], cls._model_name)
+                    cast(Union[str, PathLike], self.model_name)
                 ),
             )
-            assert cls.tokenizer is not None, "Tokenizer loading returned None"
+            assert self.tokenizer is not None, "Tokenizer loading returned None"
 
             # Load model with appropriate configuration
-            cls.model = cast(
+            self.model = cast(
                 PreTrainedModel,
                 AutoModelForCausalLM.from_pretrained(
-                    cast(Union[str, PathLike], cls._model_name),
-                    device_map=str(cls._device),
+                    cast(Union[str, PathLike], self.model_name),
+                    device_map=str(self.device),
                     torch_dtype=(
-                        torch.float16 if cls._device.type == "cuda" else torch.float32
+                        torch.float16 if self.device.type == "cuda" else torch.float32
                     ),
                 ),
             )
-            assert cls.model is not None, "Model loading returned None"
+            assert self.model is not None, "Model loading returned None"
 
-            cls._initialized = True
+            self._initialized = True
             print(
-                f"Model '{cls._model_name}' initialized successfully on {cls._device}."
+                f"Model '{self.model_name}' initialized successfully on {self.device}."
             )
             return True
         except Exception as e:
-            print(f"Model initialization failed for '{cls._model_name}': {str(e)}")
-            cls._inference_failures += 1
-            if cls._inference_failures >= cls._max_failures:
-                cls._failure_threshold_reached = True
+            print(f"Model initialization failed for '{self.model_name}': {str(e)}")
+            self._inference_failures += 1
+            if self._inference_failures >= self._max_failures:
+                self._failure_threshold_reached = True
                 print(
-                    f"Failure threshold ({cls._max_failures}) reached. Disabling model."
+                    f"Failure threshold ({self._max_failures}) reached. Disabling model."
                 )
             return False
 
     @classmethod
     def generate_text(
-        cls,
+        self,
         prompt: str,
         max_new_tokens: Optional[int] = 64,
         temperature: float = 0.7,
@@ -132,17 +132,17 @@ class ModelState:
         Returns:
             Generated text or None if generation failed
         """
-        if not cls.initialize():
+        if not self.initialize():
             return None
 
         # Safety check - both must be initialized
-        if cls.tokenizer is None or cls.model is None:
+        if self.tokenizer is None or self.model is None:
             print("Error: Tokenizer or model is None after initialization attempt.")
             return None
 
         try:
             # Create input tensors
-            input_tokens: Dict[str, torch.Tensor] = cls.tokenizer(
+            input_tokens: Dict[str, torch.Tensor] = self.tokenizer(
                 prompt, return_tensors="pt"
             )  # type: ignore
 
@@ -154,7 +154,7 @@ class ModelState:
                 raise TypeError(
                     f"Expected input_ids to be a Tensor, got {type(input_ids_tensor)}"
                 )
-            input_ids = input_ids_tensor.to(cls._device)
+            input_ids = input_ids_tensor.to(self.device)
 
             attention_mask_tensor = input_tokens.get("attention_mask")
             attention_mask = None
@@ -163,7 +163,7 @@ class ModelState:
                     raise TypeError(
                         f"Expected attention_mask to be a Tensor, got {type(attention_mask_tensor)}"
                     )
-                attention_mask = attention_mask_tensor.to(cls._device)
+                attention_mask = attention_mask_tensor.to(self.device)
 
             # Configure generation parameters
             gen_kwargs: Dict[str, Any] = {
@@ -176,7 +176,7 @@ class ModelState:
             input_length = input_ids.shape[1] if hasattr(input_ids, "shape") else 0
             model_max_length = 2048
             model_config: Optional[PretrainedConfig] = getattr(
-                cls.model, "config", None
+                self.model, "config", None
             )
             if model_config and hasattr(model_config, "max_position_embeddings"):
                 model_max_length = getattr(
@@ -191,8 +191,8 @@ class ModelState:
                 )
 
             # Handle pad_token_id carefully
-            pad_token_id: Optional[Union[int, List[int]]] = cls.tokenizer.pad_token_id  # type: ignore
-            eos_token_id: Optional[Union[int, List[int]]] = cls.tokenizer.eos_token_id  # type: ignore
+            pad_token_id: Optional[Union[int, List[int]]] = self.tokenizer.pad_token_id  # type: ignore
+            eos_token_id: Optional[Union[int, List[int]]] = self.tokenizer.eos_token_id  # type: ignore
 
             if pad_token_id is None:
                 if eos_token_id is not None:
@@ -217,7 +217,7 @@ class ModelState:
 
             # Generate text
             with torch.no_grad():
-                outputs: torch.Tensor = cls.model.generate(  # type: ignore
+                outputs: torch.Tensor = self.model.generate(  # type: ignore
                     input_ids=input_ids,
                     attention_mask=attention_mask,
                     **gen_kwargs,
@@ -235,7 +235,7 @@ class ModelState:
                     f"Warning: Could not extract output sequences from model.generate output type: {type(outputs)}"
                 )
                 newly_generated_ids = torch.tensor(
-                    [], dtype=torch.long, device=cls._device
+                    [], dtype=torch.long, device=self.device
                 )
             else:
                 first_sequence = (
@@ -248,19 +248,19 @@ class ModelState:
                     newly_generated_ids = first_sequence[input_length:]
                 else:
                     newly_generated_ids = torch.tensor(
-                        [], dtype=torch.long, device=cls._device
+                        [], dtype=torch.long, device=self.device
                     )
 
-            result = cls.tokenizer.decode(newly_generated_ids, skip_special_tokens=True)  # type: ignore
+            result = self.tokenizer.decode(newly_generated_ids, skip_special_tokens=True)  # type: ignore
 
             return result.strip()
 
         except Exception as e:
-            cls._inference_failures += 1
-            if cls._inference_failures >= cls._max_failures:
-                cls._failure_threshold_reached = True
+            self._inference_failures += 1
+            if self._inference_failures >= self._max_failures:
+                self._failure_threshold_reached = True
                 print(
-                    f"Failure threshold ({cls._max_failures}) reached. Disabling model."
+                    f"Failure threshold ({self._max_failures}) reached. Disabling model."
                 )
             print(f"Text generation failed: {str(e)}", exc_info=True)
             return None

--- a/src/word_forge/parser/lexical_functions.py
+++ b/src/word_forge/parser/lexical_functions.py
@@ -412,7 +412,12 @@ def get_thesaurus_data(word: str, thesaurus_path: str) -> List[str]:
 #                       EXAMPLE GENERATION FUNCTIONS
 # ============================================================================
 def generate_example_usage(
-    word: str, definition: str, synonyms: List[str], antonyms: List[str], pos: str
+    word: str,
+    definition: str,
+    synonyms: List[str],
+    antonyms: List[str],
+    pos: str,
+    model_state: ModelState,
 ) -> str:
     """
     Generate an example sentence for a word using a language model.
@@ -423,6 +428,7 @@ def generate_example_usage(
         synonyms: List of word synonyms
         antonyms: List of word antonyms
         pos: Part of speech
+        model_state: Initialized :class:`ModelState` instance to use for text generation
 
     Returns:
         A generated example sentence or an error message
@@ -438,8 +444,8 @@ def generate_example_usage(
         f"Example Sentence: "
     )
 
-    # Use the improved model generation method
-    full_text = ModelState.generate_text(prompt)
+    # Use the provided model state for generation
+    full_text = model_state.generate_text(prompt)
 
     if not full_text:
         return f"Could not generate example for '{word}'."
@@ -476,6 +482,7 @@ def create_lexical_dataset(
     dbnary_path: str = "data/dbnary.ttl",
     opendict_path: str = "data/opendict.json",
     thesaurus_path: str = "data/thesaurus.jsonl",
+    model_state: ModelState = None,
 ) -> LexicalDataset:
     """
     Create a comprehensive dataset of lexical information for a word.
@@ -487,10 +494,14 @@ def create_lexical_dataset(
         dbnary_path: Path to DBnary data
         opendict_path: Path to OpenDict data
         thesaurus_path: Path to Thesaurus data
+        model_state: Optional :class:`ModelState` used to generate example sentences
 
     Returns:
         Dictionary containing comprehensive lexical data from all sources
     """
+    if model_state is None:
+        model_state = ModelState()
+
     wordnet_data = get_wordnet_data(word)
 
     dataset: LexicalDataset = {
@@ -513,6 +524,7 @@ def create_lexical_dataset(
             synonyms=dataset["openthesaurus_synonyms"],
             antonyms=first_entry.get("antonyms", []),
             pos=first_entry.get("part_of_speech", ""),
+            model_state=model_state,
         )
         dataset["example_sentence"] = example
     else:

--- a/src/word_forge/parser/parser_refiner.py
+++ b/src/word_forge/parser/parser_refiner.py
@@ -473,6 +473,7 @@ class ParserRefiner:
         queue_manager: Optional[QueueManager[str]] = None,
         data_dir: str = "data",
         model_name: Optional[str] = None,
+        llm_state: Optional[ModelState] = None,
     ):
         """
         Initialize the ParserRefiner with database and queue managers.
@@ -489,9 +490,9 @@ class ParserRefiner:
         self.term_extractor = TermExtractor()
         self.stats = ProcessingStatistics()
 
-        # Configure model if specified
-        if model_name:
-            ModelState.set_model(model_name)
+        self.llm_state = llm_state or ModelState(
+            model_name or "qwen/qwen2.5-0.5b-instruct"
+        )
 
         # Initialize thread pool for parallel processing
         self._executor = ThreadPoolExecutor(max_workers=5)
@@ -523,6 +524,7 @@ class ParserRefiner:
                 dbnary_path=self.resources.get_path("dbnary"),
                 opendict_path=self.resources.get_path("opendict"),
                 thesaurus_path=self.resources.get_path("thesaurus"),
+                model_state=self.llm_state,
             )
 
             # Extract and consolidate word information


### PR DESCRIPTION
## Summary
- make `ModelState` instantiable and convert all methods to instance methods
- inject a `ModelState` instance into lexical data helpers and parser refiner
- update emotion manager and conversation models to use injected model state
- format touched files and run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b732e29dc8323bf78e93736623f70