### PR TITLE
Implement context filtering & incremental layout

### DIFF
--- a/src/word_forge/graph/graph_analysis.py
+++ b/src/word_forge/graph/graph_analysis.py
@@ -661,6 +661,21 @@ class GraphAnalysis:
         )  # Create a new graph to add filtered nodes/edges
         emotional_subgraph.add_nodes_from(base_subgraph.nodes(data=True))  # Copy nodes
 
+        context_weights_local: Optional[Dict[str, float]] = None
+        if context:
+            if isinstance(context, str):
+                context_weights_local = self.manager._emotional_contexts.get(
+                    context, {}
+                )
+                if not context_weights_local:
+                    self.logger.warning(
+                        f"Context '{context}' not found. Proceeding without weights."
+                    )
+            elif isinstance(context, dict):
+                context_weights_local = context
+            else:
+                raise TypeError("context must be a string or a dictionary of weights")
+
         for u, v, data in base_subgraph.edges(data=True):
             is_emotional = data.get("dimension") == "emotional"
             if not is_emotional:
@@ -671,15 +686,19 @@ class GraphAnalysis:
             if emotional_types is not None and rel_type not in emotional_types:
                 continue
 
-            # Filter by minimum intensity (weight)
+            # Determine weight, possibly modified by context
             weight = data.get("weight", 0.0)
+            if context_weights_local:
+                modifier = context_weights_local.get(
+                    rel_type, context_weights_local.get("default", 1.0)
+                )
+                weight *= modifier
+                data = dict(data)
+                data["weight"] = weight
+
+            # Filter by minimum intensity (after applying context)
             if weight < min_intensity:
                 continue
-
-            # TODO: Apply context filtering/weighting here when implemented
-            # if context:
-            #    apply_context_logic(data, context)
-            #    if should_exclude_based_on_context(data): continue
 
             # If all filters pass, add the edge
             emotional_subgraph.add_edge(u, v, **data)

--- a/src/word_forge/graph/graph_layout.py
+++ b/src/word_forge/graph/graph_layout.py
@@ -150,25 +150,50 @@ class GraphLayout:
             self.logger.debug("No new nodes provided for incremental layout update.")
             return
 
-        # Current simple strategy: Recompute the full layout.
-        # This is often necessary for force-directed layouts to stabilize.
-        # TODO: Explore true incremental layouts for specific algorithms if performance demands.
         self.logger.info(
-            f"Received {len(new_node_ids)} new nodes. Recomputing full layout for stability."
+            f"Received {len(new_node_ids)} new nodes. Updating layout incrementally."
         )
+
+        default_algo = self._config.default_layout
+        algo_str = (
+            default_algo.value if hasattr(default_algo, "value") else default_algo
+        )
+
+        if algo_str != "force_directed" or not self.manager._positions:
+            # Fallback to full recompute for unsupported algorithms or missing positions
+            self.logger.debug(
+                "Incremental update not supported for this layout. Recomputing full layout."
+            )
+            self.compute_layout(algorithm=algo_str)
+            return
+
         try:
-            # Ensure the default layout from config is used correctly
-            default_algo = self._config.default_layout
-            algo_str = (
-                default_algo.value if hasattr(default_algo, "value") else default_algo
+            fixed_nodes = [n for n in self.manager.g.nodes if n not in new_node_ids]
+            pos_init = {
+                n: self.manager._positions[n]
+                for n in fixed_nodes
+                if n in self.manager._positions
+            }
+            k_value = getattr(self._config, "layout_k", None)
+            iterations = getattr(self._config, "layout_iterations", 50)
+            updated_pos = nx.spring_layout(
+                self.manager.g,
+                pos=pos_init,
+                fixed=fixed_nodes,
+                dim=self.manager.dimensions,
+                k=k_value,
+                iterations=iterations,
             )
-            self.compute_layout(algorithm=algo_str)  # Pass string value
-        except GraphLayoutError as e:
+            self.manager._positions.update(cast(PositionDict, updated_pos))
+            self.logger.info(
+                f"Incremental layout update complete. Total nodes positioned: {len(self.manager._positions)}."
+            )
+        except Exception as e:
             self.logger.error(
-                f"Incremental layout update (via full recompute) failed: {e}"
+                f"Incremental layout update failed: {e}",
+                exc_info=True,
             )
-            # Re-raise or handle as needed
-            raise
+            raise GraphLayoutError(f"Incremental layout update failed: {e}") from e
 
     def _get_layout_function(self, algorithm_name: str, dimensions: int) -> callable:
         """

--- a/src/word_forge/graph/graph_manager.py
+++ b/src/word_forge/graph/graph_manager.py
@@ -387,7 +387,7 @@ class GraphManager:
             edge_dimension = dimension or self._determine_dimension(relationship)
             edge_weight = weight if weight is not None else rel_props.get("weight", 1.0)
             edge_color = color or rel_props.get(
-                "color", self._config.get_relationship_color(relationship)
+                "color", self.config.get_relationship_color(relationship)
             )
             edge_bidirectional = (
                 bidirectional

--- a/tests/test_graph_analysis.py
+++ b/tests/test_graph_analysis.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from word_forge.graph.graph_manager import GraphManager
+from word_forge.database.database_manager import DBManager
+
+
+def create_manager(tmp_path):
+    db = DBManager(tmp_path / "test.db")
+    return GraphManager(db_manager=db)
+
+
+def test_emotional_subgraph_context_filtering(tmp_path):
+    manager = create_manager(tmp_path)
+    a = manager.add_word_node("happy", {"valence": 0.8})
+    b = manager.add_word_node("joyful", {"valence": 0.9})
+    c = manager.add_word_node("sad", {"valence": -0.6})
+
+    manager.add_relationship(a, b, "joy_associated", dimension="emotional", weight=1.0)
+    manager.add_relationship(
+        a, c, "sadness_associated", dimension="emotional", weight=1.0
+    )
+
+    manager.integrate_emotional_context(
+        "clinical", {"sadness_associated": 0.2, "joy_associated": 1.0}
+    )
+
+    sub = manager.get_emotional_subgraph(
+        "happy", depth=1, context="clinical", min_intensity=0.5
+    )
+
+    terms = {manager.query.get_term_by_id(n) for n in sub.nodes}
+    assert "sad" not in terms
+    assert "joyful" in terms

--- a/tests/test_graph_layout.py
+++ b/tests/test_graph_layout.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from word_forge.graph.graph_manager import GraphManager
+from word_forge.database.database_manager import DBManager
+import numpy as np
+
+
+def create_manager(tmp_path):
+    db = DBManager(tmp_path / "layout.db")
+    return GraphManager(db_manager=db)
+
+
+def test_incremental_layout_updates_existing_positions(tmp_path):
+    manager = create_manager(tmp_path)
+    a = manager.add_word_node("a")
+    b = manager.add_word_node("b")
+
+    manager.layout.compute_layout()
+    pos_before = {
+        a: manager._positions[a],
+        b: manager._positions[b],
+    }
+
+    c = manager.add_word_node("c")
+
+    assert np.allclose(manager._positions[a], pos_before[a])
+    assert np.allclose(manager._positions[b], pos_before[b])
+    assert c in manager._positions


### PR DESCRIPTION
## Summary
- implement context weighting in `get_emotional_subgraph`
- add incremental layout update that fixes previous node positions
- fix minor bug in `GraphManager.add_relationship`
- add regression tests for emotional context filtering and layout updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b732f5a5883239731b78ea1ee1fdd