### PR TITLE
Fix config paths

### DIFF
--- a/src/word_forge/configs/config_essentials.py
+++ b/src/word_forge/configs/config_essentials.py
@@ -102,8 +102,8 @@ E = TypeVar("E")  # Error type for Result pattern
 # Project Paths
 # ==========================================
 
-# Define project paths with explicit typing for better IDE support
-PROJECT_ROOT: Final[Path] = Path("/home/lloyd/eidosian_forge/word_forge")
+# Define project paths relative to this file for portability
+PROJECT_ROOT: Final[Path] = Path(__file__).resolve().parents[3]
 DATA_ROOT: Final[Path] = PROJECT_ROOT / "data"
 LOGS_ROOT: Final[Path] = PROJECT_ROOT / "logs"
 


### PR DESCRIPTION
## Summary
- compute PROJECT_ROOT, DATA_ROOT and LOGS_ROOT dynamically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_684c03391ec48323bf0b6d71f1e668d4