### PR TITLE
Insert traceback import for graph modules

### DIFF
--- a/src/word_forge/graph/graph_analysis.py
+++ b/src/word_forge/graph/graph_analysis.py
@@ -23,6 +23,7 @@ Architecture:
 from __future__ import annotations
 
 import logging
+import traceback
 from collections import Counter, defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, cast
 

--- a/src/word_forge/graph/graph_io.py
+++ b/src/word_forge/graph/graph_io.py
@@ -21,6 +21,7 @@ Architecture:
 from __future__ import annotations
 
 import logging
+import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 


### PR DESCRIPTION
## Summary
- add `traceback` import in `graph_analysis` for error tracing
- add `traceback` import in `graph_io` for error tracing

## Testing
- `pytest -q` *(fails: DummyGraphManager() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_b_684c033d07cc8323a6956e06cc3c8640