### PR TITLE
Update ruff config to ignore archived module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ line_length = 88
 
 [tool.ruff]
 line-length = 88
+exclude = ["src/old"]
 
 [tool.mypy]
 python_version           = "3.8"


### PR DESCRIPTION
## Summary
- update `pyproject.toml` to ignore `src/old` in Ruff

## Testing
- `python /tmp/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_684c034012848323900d12a8fe16c2eb