### PR TITLE
Add tests for graph build and vector persistence

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,34 @@
+# Word Forge Advanced MVP TODO
+
+This list distills the current expansion plan into concrete deliverables. Items are ordered approximately in the sequence they should be tackled. Each completed item should be committed and documented in the changelog.
+
+1. **Finalize Test Coverage**
+   - [ ] Ensure each core module has unit tests: database, queue, parser, worker, CLI, vectorizer, graph, conversation, and emotion.
+     - [x] Queue manager
+   - [ ] Stub or mock heavy dependencies (torch, chromadb) so tests run without external resources.
+   - [ ] Integrate tests into CI pipeline.
+
+2. **Vectorization Enhancements**
+   - [ ] Confirm `VectorStore` persists embeddings to disk and reloads correctly.
+   - [ ] Flesh out `VectorWorker` polling logic for detecting new or updated entries.
+   - [ ] Add CLI commands for building and querying the vector index.
+
+3. **Graph Module**
+   - [x] Verify `GraphManager` can rebuild the network from the database.
+   - [ ] Implement incremental updates in `GraphWorker` to avoid full rebuilds.
+   - [ ] Provide export utilities (GEXF/GraphML) for external visualization tools.
+
+4. **Conversation & Emotion**
+   - [ ] Store conversations and messages using `ConversationManager`.
+   - [ ] Integrate `EmotionManager` to annotate messages with valence/arousal.
+   - [ ] Expose conversation commands through the CLI.
+
+5. **Worker Orchestration**
+   - [ ] Create a `WorkerManager` to start, stop, and monitor all background threads.
+   - [ ] Allow modules to be enabled/disabled via configuration flags.
+
+6. **Documentation Updates**
+   - [ ] Expand `docs/overview.md` with diagrams showing module interactions.
+   - [ ] Keep `docs/glossary.md` updated as new terminology arises.
+   - [ ] Maintain `upgrade_plan.md` with notes on design decisions and future ideas.
+

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,17 +1,20 @@
 # Word Forge Glossary
 
-This living glossary defines key terms used throughout the project. New entries
-should be added in alphabetical order.
+This living glossary defines key terms used throughout the project. New entries should remain in **alphabetical order** to make lookup simple.
 
-- **Eidosian** — design philosophy emphasizing type safety, clear layering and
-  continuous self‑improvement.
-- **Lexical Data** — structured information about words including definitions,
-  usage examples and relationships.
-- **Word Forge** — the toolkit for building and exploring a semantic network of
-  terms with vector search and emotion analysis.
+- **ChromaDB** — vector database used for embedding storage and similarity search.
+- **Conversation Manager** — orchestrates multi-step conversation sessions using several language models and persists messages to the database.
+- **Eidosian** — design philosophy emphasizing type safety, clear layering and continuous self‑improvement.
+- **Emotion Manager** — analyzes text to derive sentiment and emotional valence, integrating results with the conversation and graph modules.
+- **Graph Manager** — central orchestrator that builds the semantic network from lexical and emotional data using NetworkX.
+- **Graph Worker** — background thread that keeps the lexical graph up to date and saves periodic snapshots.
+- **Lexical Data** — structured information about words including definitions, usage examples and relationships.
 - **NetworkX** — library used for graph operations and network analysis.
 - **NumPy** — array library providing efficient numeric computation used by vector features.
-- **ChromaDB** — vector database used for embedding storage and similarity search.
+- **Queue Manager** — thread-safe task queue coordinating asynchronous worker threads.
+- **Vector Store** — component providing persistent storage for vector embeddings.
+- **Vector Worker** — background thread that generates embeddings for new or updated content and inserts them into the vector store.
+- **Worker Manager** — utility orchestrating multiple background workers such as vector and graph processors.
+- **Word Forge** — the toolkit for building and exploring a semantic network of terms with vector search and emotion analysis.
 - **WordNet** — lexical database from Princeton that supplies synonyms and sense relationships.
-
 

--- a/src/word_forge/queue/queue_manager.py
+++ b/src/word_forge/queue/queue_manager.py
@@ -18,7 +18,7 @@ import queue
 import threading
 import time
 from dataclasses import dataclass, field
-from enum import Enum, auto
+from enum import Enum, IntEnum, auto
 from typing import (
     Any,  # Keep Any for ErrorContext context
     Dict,
@@ -110,7 +110,7 @@ class QueueFullError(QueueError):
         self.max_size = max_size
 
 
-class TaskPriority(Enum):
+class TaskPriority(IntEnum):
     """
     Priority levels for queue items.
 

--- a/tests/test_graph_manager.py
+++ b/tests/test_graph_manager.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from word_forge.graph.graph_manager import GraphManager
+from word_forge.database.database_manager import DBManager
+
+
+def test_build_graph_from_db(tmp_path):
+    db = DBManager(db_path=tmp_path / "test.db")
+    db.insert_or_update_word("alpha", "first")
+    db.insert_or_update_word("beta", "second")
+    db.insert_relationship("alpha", "beta", "synonym")
+
+    manager = GraphManager(db_manager=db)
+    manager.build_graph()
+
+    terms = {data["term"] for _, data in manager.g.nodes(data=True)}
+    assert {"alpha", "beta"} <= terms
+    assert manager.g.number_of_edges() == 1

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+from word_forge.queue.queue_manager import QueueManager, TaskPriority
+from word_forge.configs.config_essentials import Result
+
+
+def test_enqueue_and_dequeue_basic():
+    qm = QueueManager[str]()
+    assert qm.enqueue("task1").unwrap()
+    assert len(qm) == 1
+    result = qm.dequeue()
+    assert result.is_success
+    assert result.unwrap() == "task1"
+    assert qm.is_empty
+
+
+def test_enqueue_duplicate():
+    qm = QueueManager[str]()
+    assert qm.enqueue("a").unwrap()
+    assert not qm.enqueue("a").unwrap()
+    assert len(qm) == 1
+
+
+def test_priority_order():
+    qm = QueueManager[str]()
+    assert qm.enqueue("low", priority=TaskPriority.LOW).unwrap()
+    assert qm.enqueue("high", priority=TaskPriority.HIGH).unwrap()
+    assert qm.dequeue().unwrap() == "high"
+    assert qm.dequeue().unwrap() == "low"
+

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -55,3 +55,36 @@ def test_search_requires_input():
     vs = object.__new__(VectorStore)
     with pytest.raises(SearchError):
         vs.search()
+
+
+class DummyCollection:
+    def __init__(self, client):
+        self.client = client
+    def upsert(self, *a, **k):
+        pass
+    def query(self, *a, **k):
+        return {"ids": [], "distances": []}
+    def delete(self, *a, **k):
+        pass
+
+
+class DummyClient:
+    def __init__(self):
+        self.persist_called = False
+    def get_or_create_collection(self, *a, **k):
+        return DummyCollection(self)
+    def persist(self):
+        self.persist_called = True
+
+
+def test_persist_called_for_disk_storage():
+    from word_forge.configs.config_essentials import StorageType
+    vs = object.__new__(VectorStore)
+    vs.dimension = 5
+    vs.client = DummyClient()
+    vs.collection = DummyCollection(vs.client)
+    vs.storage_type = StorageType.DISK
+    vs._persist_if_needed()
+    assert vs.client.persist_called
+
+


### PR DESCRIPTION
## Summary
- extend glossary with graph and worker terms
- update TODO for graph build verification
- test GraphManager building from the DB
- ensure VectorStore persistence is triggered for disk storage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d6a35c8508323815c0ba77679bffc