### PR TITLE
Add CLI progress logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ You can also control the number of worker threads:
 word_forge start apple --minutes 5 --workers 2
 ```
 
+While running, the CLI prints periodic progress reports indicating how many
+words have been processed, how many succeeded or failed, and the remaining
+queue size. This provides real‑time insight into long running operations.
+
 ## Development and Contributing
 
 Style and tooling are managed through **Black** and **Ruff**. Tests are implemented with **pytest** and run automatically by the CI workflow.

--- a/src/word_forge/forge.py
+++ b/src/word_forge/forge.py
@@ -93,9 +93,21 @@ def start(
         )
 
     start_time = time.time()
+    last_report = start_time
     try:
         while True:
             time.sleep(0.5)
+            if time.time() - last_report >= 5:
+                status = worker_pool.get_status()
+                stats = status["stats"]
+                LOGGER.info(
+                    "Progress - processed:%d success:%d errors:%d queue:%d",
+                    stats.get("processed_count", 0),
+                    stats.get("success_count", 0),
+                    stats.get("error_count", 0),
+                    status.get("queue_size", 0),
+                )
+                last_report = time.time()
             if (
                 run_minutes is not None
                 and (time.time() - start_time) > run_minutes * 60


### PR DESCRIPTION
## Summary
- show worker progress in `word_forge start`
- document real-time progress in README

## Testing
- `pytest -q`
- `ruff check src`

------
https://chatgpt.com/codex/tasks/task_b_684d74e13fc8832399b5c92162a1dfff