### PR TITLE
Implement GraphWorker restart factory

### DIFF
--- a/src/word_forge/graph/graph_worker.py
+++ b/src/word_forge/graph/graph_worker.py
@@ -192,39 +192,11 @@ class GraphWorker(threading.Thread):
                     f"Cannot resume worker in state: {self._current_state}"
                 )
 
-    def restart(self) -> None:
-        """
-        Restart the worker thread gracefully.
+    def restart(self) -> "GraphWorker":
+        """Restart the worker and return the new running instance."""
+        from .worker_factory import restart_worker
 
-        Stops the current thread if running, waits for it to terminate,
-        resets internal state, and starts a new thread instance.
-        Note: This creates a *new* thread object. The old one cannot be restarted.
-        """
-        self.logger.info("GraphWorker restart requested...")
-        if self.is_alive():
-            self.stop()
-            self.join(
-                timeout=self.poll_interval + 5.0
-            )  # Wait a bit longer than poll interval
-            if self.is_alive():
-                self.logger.warning(
-                    "Worker thread did not terminate cleanly during restart."
-                )
-                # Cannot truly force stop a thread, but proceed with creating a new one
-
-        # Reset state for a *conceptual* restart (a new instance would be needed)
-        # This method is problematic for standard threading. A manager process
-        # would typically handle creating a new worker instance.
-        # For now, log the limitation.
-        self.logger.warning(
-            "Thread restart requires creating a new GraphWorker instance. This method only stops the current thread."
-        )
-        # If this instance were to be reused (not standard):
-        # self._stop_event.clear()
-        # self._pause_event.clear()
-        # self._last_update = None
-        # ... reset other state ...
-        # self.start() # This would raise RuntimeError if called on same thread object
+        return restart_worker(self)
 
     def run(self) -> None:
         """

--- a/src/word_forge/graph/worker_factory.py
+++ b/src/word_forge/graph/worker_factory.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type hints
+    from .graph_worker import GraphWorker
+
+
+def restart_worker(worker: "GraphWorker") -> "GraphWorker":
+    """Stop ``worker`` and return a new running ``GraphWorker`` instance."""
+    worker.logger.info("Restarting GraphWorker via factory helper...")
+    worker.stop()
+    worker.join(timeout=worker.poll_interval + 5.0)
+    if worker.is_alive():
+        worker.logger.warning("Worker thread did not terminate cleanly during restart.")
+
+    from .graph_worker import GraphWorker  # Local import to avoid circular dependency
+
+    new_worker = GraphWorker(
+        graph_manager=worker.graph_manager,
+        poll_interval=worker.poll_interval,
+        output_path=worker.output_path,
+        visualization_path=worker.visualization_path,
+        daemon=worker.daemon,
+    )
+    new_worker.start()
+    return new_worker

--- a/tests/test_graph_worker.py
+++ b/tests/test_graph_worker.py
@@ -1,0 +1,55 @@
+import sys
+import types
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Provide a lightweight GraphManager stub so GraphWorker can be imported
+gm_mod = types.ModuleType("word_forge.graph.graph_manager")
+
+class DummyGraphManager:
+    def build_graph(self):
+        pass
+
+    def get_node_count(self) -> int:
+        return 0
+
+    def save_to_gexf(self, path: str) -> None:
+        pass
+
+    def visualize(self, output_path: str, open_in_browser: bool = False) -> None:
+        pass
+
+gm_mod.GraphManager = DummyGraphManager
+sys.modules["word_forge.graph.graph_manager"] = gm_mod
+
+from word_forge.graph.graph_worker import GraphWorker
+
+
+def test_restart_returns_running_worker(tmp_path, monkeypatch):
+    manager = DummyGraphManager()
+    worker = GraphWorker(
+        graph_manager=manager,
+        poll_interval=0.01,
+        output_path=str(tmp_path / "gexf.gexf"),
+        visualization_path=str(tmp_path / "vis.html"),
+    )
+
+    def quick_cycle(self):
+        time.sleep(0.02)
+        self.stop()
+
+    monkeypatch.setattr(GraphWorker, "_execute_update_cycle", quick_cycle)
+
+    worker.start()
+    worker.join(timeout=1)
+    assert not worker.is_alive()
+
+    new_worker = worker.restart()
+    assert new_worker is not worker
+    time.sleep(0.01)
+    assert new_worker.is_alive()
+
+    new_worker.stop()
+    new_worker.join(timeout=1)


### PR DESCRIPTION
## Summary
- refactor `GraphWorker.restart` to delegate to a new factory
- add `worker_factory.restart_worker` helper for external use
- provide tests for restarting a worker thread

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d92b503208323b71a07ef6c149f54