### PR TITLE
Implement WorkerManager and add tests

### DIFF
--- a/src/word_forge/forge.py
+++ b/src/word_forge/forge.py
@@ -62,6 +62,11 @@ def start(
         WordProcessor,
         WorkerPoolConfig,
     )
+    from word_forge.queue.worker_manager import WorkerManager
+    from word_forge.graph.graph_manager import GraphManager
+    from word_forge.graph.graph_worker import GraphWorker
+    from word_forge.vectorizer.vector_store import VectorStore
+    from word_forge.vectorizer.vector_worker import VectorWorker
     from word_forge.configs.config_essentials import measure_execution
 
     _setup_logging()
@@ -76,6 +81,17 @@ def start(
     pool_config = WorkerPoolConfig(worker_count=worker_count)
     worker_pool = ParallelWordProcessor(processor, config=pool_config, logger=LOGGER)
 
+    graph_manager = GraphManager(db_manager=db_manager)
+    graph_worker = GraphWorker(graph_manager=graph_manager)
+
+    vector_store = VectorStore(db_manager=db_manager)
+    vector_worker = VectorWorker(db=db_manager, vector_store=vector_store, embedder="MiniLM")
+
+    manager = WorkerManager(logger=LOGGER)
+    manager.register(worker_pool)
+    manager.register(graph_worker)
+    manager.register(vector_worker)
+
     seeds = (
         list(seed_words)
         if seed_words is not None
@@ -85,10 +101,9 @@ def start(
         queue_manager.enqueue(term)
 
     with measure_execution("forge.start", {"workers": worker_count}) as metrics:
-        worker_pool.start()
+        manager.start_all()
         LOGGER.info(
-            "Worker pool started with %d workers in %.1fms",
-            worker_count,
+            "Workers started in %.1fms",
             metrics.duration_ms,
         )
 
@@ -113,13 +128,12 @@ def start(
                 and (time.time() - start_time) > run_minutes * 60
             ):
                 break
-            if queue_manager.is_empty and not worker_pool._active:
-                # Nothing left to process and workers stopped
+            if queue_manager.is_empty and not manager.any_alive():
                 break
     except KeyboardInterrupt:
         LOGGER.info("Interrupted by user")
     finally:
-        worker_pool.stop()
+        manager.stop_all()
         parser_refiner.shutdown()
         db_manager.close()
         LOGGER.info("Word Forge stopped")

--- a/src/word_forge/queue/__init__.py
+++ b/src/word_forge/queue/__init__.py
@@ -1,0 +1,3 @@
+from .worker_manager import WorkerManager, Worker
+
+__all__ = ["WorkerManager", "Worker"]

--- a/src/word_forge/queue/worker_manager.py
+++ b/src/word_forge/queue/worker_manager.py
@@ -1,0 +1,68 @@
+"""Worker management utilities for Word Forge."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Optional, Protocol
+
+
+class Worker(Protocol):
+    """Minimal protocol all workers must implement."""
+
+    def start(self) -> None:
+        ...
+
+    def stop(self) -> None:
+        ...
+
+    def is_alive(self) -> bool:
+        ...
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        ...
+
+
+class WorkerManager:
+    """Register and control background workers."""
+
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        self.logger = logger or logging.getLogger(__name__)
+        self._workers: List[Worker] = []
+
+    def register(self, worker: Worker) -> None:
+        """Add a worker to be managed."""
+        self._workers.append(worker)
+        self.logger.debug("Registered worker %s", worker)
+
+    def start_all(self) -> None:
+        """Start all registered workers."""
+        for w in self._workers:
+            try:
+                w.start()
+                self.logger.debug("Started worker %s", w)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.logger.error("Failed to start %s: %s", w, exc)
+
+    def stop_all(self, join: bool = True, timeout: float = 5.0) -> None:
+        """Stop all workers and optionally join their threads."""
+        for w in self._workers:
+            try:
+                w.stop()
+                self.logger.debug("Stopped worker %s", w)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.logger.error("Failed to stop %s: %s", w, exc)
+
+        if join:
+            for w in self._workers:
+                if hasattr(w, "join"):
+                    try:
+                        w.join(timeout=timeout)
+                    except Exception:
+                        pass
+
+    def any_alive(self) -> bool:
+        """Check if any managed worker is still running."""
+        return any(w.is_alive() for w in self._workers)
+
+    def __iter__(self) -> Iterable[Worker]:
+        return iter(self._workers)

--- a/tests/test_worker_manager.py
+++ b/tests/test_worker_manager.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from word_forge.queue.worker_manager import WorkerManager
+
+
+class DummyWorker:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def is_alive(self) -> bool:
+        return self.started and not self.stopped
+
+    def join(self, timeout=None):
+        pass
+
+
+def test_start_and_stop_all():
+    w1 = DummyWorker()
+    w2 = DummyWorker()
+    manager = WorkerManager()
+    manager.register(w1)
+    manager.register(w2)
+
+    manager.start_all()
+    assert w1.started and w2.started
+    assert manager.any_alive()
+
+    manager.stop_all()
+    assert w1.stopped and w2.stopped
+    assert not manager.any_alive()


### PR DESCRIPTION
## Summary
- add `WorkerManager` for orchestrating worker lifecycle
- integrate new manager with CLI start flow
- expose WorkerManager via queue package
- test WorkerManager basics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d93c422548323b55cca4f48c3166c