### PR TITLE
Improve Word Forge CLI resilience

### DIFF
--- a/src/word_forge/database/database_manager.py
+++ b/src/word_forge/database/database_manager.py
@@ -465,6 +465,8 @@ class DBManager:
 
         try:
             self._ensure_database_directory()
+            # Ensure schema exists on initialization for convenience
+            self.create_tables()
         except Exception as e:
             raise ConnectionError(
                 f"Failed to create database directory for {self.db_path}",

--- a/src/word_forge/emotion/emotion_manager.py
+++ b/src/word_forge/emotion/emotion_manager.py
@@ -38,8 +38,17 @@ from contextlib import contextmanager
 from functools import lru_cache
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union, cast
 
-from nltk.sentiment.vader import SentimentIntensityAnalyzer  # type: ignore
-from textblob import TextBlob  # type: ignore
+try:  # Optional dependencies
+    from nltk.sentiment.vader import SentimentIntensityAnalyzer  # type: ignore
+    VADER_AVAILABLE = True
+except Exception:  # pragma: no cover - allow missing VADER
+    SentimentIntensityAnalyzer = None  # type: ignore
+    VADER_AVAILABLE = False
+
+try:
+    from textblob import TextBlob  # type: ignore
+except Exception:  # pragma: no cover - allow missing TextBlob
+    TextBlob = None  # type: ignore
 
 from word_forge.database.database_manager import DBManager
 from word_forge.emotion.emotion_config import (
@@ -63,7 +72,6 @@ from word_forge.emotion.emotion_types import (
 from word_forge.parser.language_model import ModelState
 
 logger = logging.getLogger(__name__)
-VADER_AVAILABLE = True
 LLM_AVAILABLE = True
 
 # Set of positive emotion categories for efficient categorization

--- a/src/word_forge/parser/language_model.py
+++ b/src/word_forge/parser/language_model.py
@@ -1,15 +1,41 @@
 # Import PathLike for model paths
 from os import PathLike
 from typing import Any, Dict, List, Optional, Union, cast
-import torch
-from transformers import (  # type: ignore
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    PretrainedConfig,  # Import PretrainedConfig
-    PreTrainedModel,
-    PreTrainedTokenizer,
-    PreTrainedTokenizerFast,
-)
+
+try:  # Optional heavy dependencies
+    import torch
+    from transformers import (  # type: ignore
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        PretrainedConfig,
+        PreTrainedModel,
+        PreTrainedTokenizer,
+        PreTrainedTokenizerFast,
+    )
+except Exception:  # pragma: no cover - optional dependency handling
+    class _FakeTorch:
+        """Minimal stub when PyTorch is unavailable."""
+
+        Tensor = Any
+
+        @staticmethod
+        def no_grad():  # type: ignore
+            class _Ctx:
+                def __enter__(self):
+                    return None
+
+                def __exit__(self, *exc: Any) -> None:
+                    pass
+
+            return _Ctx()
+
+    torch = cast(Any, _FakeTorch())
+    AutoModelForCausalLM = None  # type: ignore
+    AutoTokenizer = None  # type: ignore
+    PretrainedConfig = Any  # type: ignore
+    PreTrainedModel = Any  # type: ignore
+    PreTrainedTokenizer = Any  # type: ignore
+    PreTrainedTokenizerFast = Any  # type: ignore
 
 
 class ModelState:
@@ -24,12 +50,15 @@ class ModelState:
     def __init__(
         self,
         model_name: str = "qwen/qwen2.5-0.5b-instruct",
-        device: Optional[torch.device] = None,
+        device: Optional[Any] = None,
     ) -> None:
         self.model_name = model_name
-        self.device = device or torch.device(
-            "cuda" if torch.cuda.is_available() else "cpu"
-        )
+        if torch is not None and hasattr(torch, "device"):
+            self.device = device or torch.device(
+                "cuda" if torch.cuda.is_available() else "cpu"
+            )
+        else:
+            self.device = "cpu"
         self.tokenizer: Optional[
             Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
         ] = None
@@ -69,6 +98,9 @@ class ModelState:
             return False
 
         try:
+            if torch is None or AutoTokenizer is None or AutoModelForCausalLM is None:
+                raise ImportError("transformers or torch not available")
+
             # Load tokenizer with explicit type annotation
             self.tokenizer = cast(
                 Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
@@ -85,7 +117,7 @@ class ModelState:
                     cast(Union[str, PathLike], self.model_name),
                     device_map=str(self.device),
                     torch_dtype=(
-                        torch.float16 if self.device.type == "cuda" else torch.float32
+                        torch.float16 if getattr(self.device, "type", "cpu") == "cuda" else torch.float32
                     ),
                 ),
             )
@@ -127,6 +159,10 @@ class ModelState:
             Generated text or None if generation failed
         """
         if not self.initialize():
+            return None
+
+        if torch is None:
+            print("Text generation skipped: torch not available")
             return None
 
         # Safety check - both must be initialized

--- a/src/word_forge/queue/worker_manager.py
+++ b/src/word_forge/queue/worker_manager.py
@@ -62,7 +62,15 @@ class WorkerManager:
 
     def any_alive(self) -> bool:
         """Check if any managed worker is still running."""
-        return any(w.is_alive() for w in self._workers)
+        alive = False
+        for w in self._workers:
+            try:
+                if hasattr(w, "is_alive") and w.is_alive():
+                    alive = True
+                    break
+            except Exception:
+                continue
+        return alive
 
     def __iter__(self) -> Iterable[Worker]:
         return iter(self._workers)

--- a/src/word_forge/vectorizer/vector_store.py
+++ b/src/word_forge/vectorizer/vector_store.py
@@ -40,10 +40,15 @@ from typing import (
     overload,
 )
 
-import chromadb
+try:  # Optional heavy dependencies
+    import chromadb
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover - allow running without chromadb
+    chromadb = None  # type: ignore
+    SentenceTransformer = None  # type: ignore
+
 import numpy as np
 from numpy.typing import NDArray
-from sentence_transformers import SentenceTransformer
 
 from word_forge.config import config
 from word_forge.database.database_manager import DatabaseError, DBManager, WordEntryDict
@@ -369,6 +374,20 @@ class VectorStore:
         """
         # Set up logging
         self.logger = logging.getLogger(__name__)
+
+        # Fallback if optional dependencies are missing
+        if chromadb is None or SentenceTransformer is None:
+            self.index_path = Path(index_path or "")
+            self.storage_type = StorageType.MEMORY
+            self.db_manager = db_manager
+            self.emotion_manager = emotion_manager
+            self.model_name = model_name or "simple"
+            self.dimension = dimension or 768
+            self.client = None
+            self.collection = {}  # type: ignore[var-annotated]
+            self.instruction_templates = {}
+            self.logger.warning("ChromaDB not available, using in-memory vector store")
+            return
 
         # Store configuration, using defaults from config object
         self.index_path = Path(index_path or config.vectorizer.index_path)
@@ -998,16 +1017,22 @@ class VectorStore:
         sanitized_metadata = self._sanitize_metadata(metadata or {})
 
         try:
-            # Upsert into collection
-            self.collection.upsert(
-                ids=[vec_id_str],
-                embeddings=[embedding.tolist()],
-                metadatas=[sanitized_metadata] if sanitized_metadata else None,
-                documents=[text] if text else None,
-            )
+            if isinstance(self.collection, dict):
+                self.collection[vec_id_str] = {
+                    "embedding": embedding,
+                    "metadata": sanitized_metadata,
+                    "text": text,
+                }
+            else:
+                self.collection.upsert(
+                    ids=[vec_id_str],
+                    embeddings=[embedding.tolist()],
+                    metadatas=[sanitized_metadata] if sanitized_metadata else None,
+                    documents=[text] if text else None,
+                )
 
-            # Persist to disk if using persistent storage
-            self._persist_if_needed()
+                # Persist to disk if using persistent storage
+                self._persist_if_needed()
 
         except Exception as e:
             raise UpsertError(f"Failed to store vector: {str(e)}") from e

--- a/src/word_forge/vectorizer/vector_worker.py
+++ b/src/word_forge/vectorizer/vector_worker.py
@@ -30,7 +30,10 @@ from enum import Enum, auto
 from typing import Dict, List, Optional, Protocol, TypedDict, Union, cast, final
 
 import numpy as np
-import torch
+try:  # Optional heavy dependency
+    import torch
+except Exception:  # pragma: no cover - allow missing torch
+    torch = None  # type: ignore
 from numpy.typing import NDArray
 
 from word_forge.database.database_manager import DBManager
@@ -654,7 +657,7 @@ class TransformerEmbedder:
                 show_progress_bar=True,  # Show Progress
                 output_value="sentence_embedding",  # Ensure correct output
                 precision="float32",  # Use float32 for consistency
-                device="cuda" if torch.cuda.is_available() else "cpu",
+                device="cuda" if torch is not None and torch.cuda.is_available() else "cpu",
             )
             return cast(NDArray[np.float32], embedding)
         except Exception as e:


### PR DESCRIPTION
## Summary
- allow running without optional heavy dependencies
- fall back to in-memory vector store when ChromaDB is missing
- lazily handle missing torch and transformers in `ModelState`
- make `WorkerManager.any_alive` tolerant of workers lacking `is_alive`
- create DB tables during `DBManager` init

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m word_forge.forge start --minutes 0.02 --workers 1`

------
https://chatgpt.com/codex/tasks/task_b_684d81f9fb408323a3ebe8c3a2d230d1